### PR TITLE
fix: quick fix for crash on deprecated setting

### DIFF
--- a/ui/machine_panel.go
+++ b/ui/machine_panel.go
@@ -65,6 +65,11 @@ func (t MachineLimitPanelContent) GetColumnCount() int { return 2 }
 
 func (t MachineLimitPanelContent) GetCell(row int, column int) *tview.TableCell {
 	limit := MachineLimits.Members()[row]
+	toolhead := t.tui.State["toolhead"]
+	currentValue := toolhead[limit.Value.StatusKey]
+	if currentValue == nil {
+		return nil
+	}
 	switch column {
 	case 0:
 		return tview.NewTableCell(" " + limit.Value.DisplayName).SetMaxWidth(0).SetExpansion(2).SetSelectable(true).SetClickedFunc(func() bool {
@@ -72,9 +77,6 @@ func (t MachineLimitPanelContent) GetCell(row int, column int) *tview.TableCell 
 			return false
 		})
 	case 1:
-		toolhead := t.tui.State["toolhead"]
-		currentValue := toolhead[limit.Value.StatusKey]
-
 		return tview.NewTableCell(fmt.Sprintf("%s %-5s", strconv.FormatFloat(currentValue.(float64), 'f', 0, 64), limit.Value.Unit)).SetMaxWidth(12).SetAlign(tview.AlignRight).SetExpansion(0).SetSelectable(true).SetClickedFunc(func() bool {
 			t.onSelected(row, column)
 			return false


### PR DESCRIPTION
The `max_accel_to_decel` printer setting is deprecated according to https://www.klipper3d.org/Config_Reference.html#printer. Since the cast to float is unchecked, there is a crash if using recent klipper when trying to create the cell for this setting.

The rows created should probably be dynamic (like temperature?) but the blank row does no real harm and I thought a quick fix might be okay for now.