### PR TITLE
fix: ExecuteGcode starts go routine so caller should not

### DIFF
--- a/ui/toolhead_panel.go
+++ b/ui/toolhead_panel.go
@@ -106,7 +106,7 @@ func (t ToolheadPanelContent) onSelected(row int, column int) {
 }
 
 func (t *ToolheadPanelContent) homeAxis(axis string) {
-	go t.tui.ExecuteGcode("G28 " + axis)
+	t.tui.ExecuteGcode("G28 " + axis)
 }
 
 func (t *ToolheadPanelContent) setZOffset() {
@@ -158,7 +158,7 @@ func (t *ToolheadPanelContent) doMove(axis string) {
 }
 
 func (t ToolheadPanelContent) homeAll() {
-	go t.tui.ExecuteGcode("G28")
+	t.tui.ExecuteGcode("G28")
 }
 
 func (t *ToolheadPanelContent) buildAxis(axis string, color tcell.Color) []*tview.TableCell {


### PR DESCRIPTION
This was an obvious fix but I am a little tempted to move the goroutine creation on all the `promptForInput` calls into the TUI to simplify the calling code *and* would also make it easier to write tests for the panel code.